### PR TITLE
Fixes issue with option or quantity change causing wrong number of de…

### DIFF
--- a/_partials/cartBox/item_modal.php
+++ b/_partials/cartBox/item_modal.php
@@ -3,7 +3,7 @@
   data-control="cart-item"
   data-min-quantity="<?= $menuItem->minimum_qty; ?>" 
   data-price-amount="<?= $cartItem ? $cartItem->price : $menuItem->getBuyablePrice() ?>"
-  data-price-format="<?= currency_format(0); ?>"
+  data-price-format="<?= currency_format(0, 0, False); ?>"
 >
   <form method="POST" data-request="<?= $formHandler; ?>">
     <div class="modal-content">

--- a/_partials/cartBox/item_modal.php
+++ b/_partials/cartBox/item_modal.php
@@ -1,9 +1,9 @@
 <div
   class="modal-dialog "
   data-control="cart-item"
-  data-min-quantity="<?= $menuItem->minimum_qty; ?>" 
+  data-min-quantity="<?= $menuItem->minimum_qty; ?>"
   data-price-amount="<?= $cartItem ? $cartItem->price : $menuItem->getBuyablePrice() ?>"
-  data-price-format="<?= currency_format(0, 0, False); ?>"
+  data-price-format="<?= currency_format(0, 0,false); ?>"
 >
   <form method="POST" data-request="<?= $formHandler; ?>">
     <div class="modal-content">


### PR DESCRIPTION
…cimals

Commit #70ad05d on tastyigniter/ti-ext-cart doesn't consider different currency symbol position than in front of the price amount when calculating decimal length, but if the currency symbol is after the price amount, the decimal length is calculated wrongly, counting currency symbol too. This fixes it by not including currency symbol in price-format data