### PR TITLE
fix(pagination): wrap paginator URLs with url() helper to avoid relative href 404s

### DIFF
--- a/resources/views/pagination/default.blade.php
+++ b/resources/views/pagination/default.blade.php
@@ -3,7 +3,7 @@
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">«</span></li>
         @else
-            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">«</a></li>
+            <li class="page-item"><a class="page-link" href="{{ url($paginator->previousPageUrl()) }}" rel="prev">«</a></li>
         @endif
 
         @for ($page = 1; $page <= $paginator->lastPage(); $page++)
@@ -20,7 +20,7 @@
         @endfor
 
         @if ($paginator->hasMorePages())
-            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">»</a></li>
+            <li class="page-item"><a class="page-link" href="{{ url($paginator->nextPageUrl()) }}" rel="next">»</a></li>
         @else
             <li class="page-item disabled"><span class="page-link">»</span></li>
         @endif

--- a/resources/views/pagination/simple_default.blade.php
+++ b/resources/views/pagination/simple_default.blade.php
@@ -5,7 +5,7 @@
         @else
             <li>
                 <a
-                    href="{{ $paginator->previousPageUrl() }}"
+                    href="{{ url($paginator->previousPageUrl()) }}"
                     rel="prev"
                 >@lang('pagination.previous')</a>
             </li>
@@ -14,7 +14,7 @@
         @if ($paginator->hasMorePages())
             <li>
                 <a
-                    href="{{ $paginator->nextPageUrl() }}"
+                    href="{{ url($paginator->nextPageUrl()) }}"
                     rel="next"
                 >@lang('pagination.next')</a>
             </li>

--- a/theme.php
+++ b/theme.php
@@ -1,7 +1,9 @@
 <?php
 
+use Igniter\System\Models\Country;
+
 // add country & currency helper
-$defaultCountry = \Igniter\System\Models\Country::getDefault();
+$defaultCountry = Country::getDefault();
 $defaultCurrency = currency()->getDefault();
 $jsVars = [];
 if ($defaultCountry) {


### PR DESCRIPTION
## Summary

Pagination links (`next`/`prev`) on Livewire-paginated views (e.g. menu list, reservation list, address book) navigate to a 404 on multi-segment routes such as `/:location?/local/menus`.

## Root cause

`Livewire\Features\SupportPagination\SupportPagination::setPathResolvers()` overrides `Paginator::currentPathResolver()` to return `Livewire::originalPath()`, which is `request()->path()` — a **relative** path with no leading slash (e.g. `default/menus`). The default and simple_default pagination views in this theme pass that value straight into `href`:

```blade
href="{{ $paginator->nextPageUrl() }}"
```

The browser resolves a relative href against the current document path. On a single-segment route (`/menus`) the relative resolution happens to land on the right URL, so the bug is invisible. On multi-segment routes — e.g. `/default/menus` — the browser strips the last segment and concatenates, producing `/default/default/menus?page=2` → 404.

Reproducible on a stock TastyIgniter install with the orange theme by visiting `/<location>/local/menus` with enough menu items to exceed `itemsPerPage` and clicking *Next*.

## Fix

Wrap `previousPageUrl()` / `nextPageUrl()` with the `url()` helper in both pagination partials. `url()` (Laravel's `URL::to()`) produces an absolute URL when given a relative path, so the rendered href is always rooted regardless of how the path resolver is configured.

```blade
href="{{ url($paginator->nextPageUrl()) }}"
```

Verified by curling the rendered page before/after — the href changes from `default/menus?page=2` to `https://example.test/default/menus?page=2`, and page 2 returns 200 with the expected items.

## Test plan
- [ ] Visit a Livewire-paginated page on a multi-segment route, click *Next* — should load page 2 (was 404).
- [ ] Visit the same on a single-segment route — should still load page 2 (no regression).
- [ ] Numbered pagination view (`default.blade.php`) prev/next links still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)