### PR TITLE
Honour location ASAP/Later restriction in fulfillment modal

### DIFF
--- a/resources/views/includes/local/timeslot.blade.php
+++ b/resources/views/includes/local/timeslot.blade.php
@@ -1,3 +1,4 @@
+@if ($showAsapOption ?? true)
 <div class="form-check py-2 border-bottom">
     <input
         wire:model="isAsap"
@@ -14,6 +15,8 @@
         for="isAsap"
     >@lang('igniter.local::default.text_asap')</label>
 </div>
+@endif
+@if ($showLaterOption ?? true)
 <div class="form-check py-2">
     <input
         wire:model="isAsap"
@@ -30,6 +33,7 @@
         for="isLater"
     >@lang('igniter.local::default.text_later')</label>
 </div>
+@endif
 <div x-cloak x-show="showTimePicker">
     <div class="row gx-3 mt-2 mx-4 mb-3">
         <div class="col">

--- a/src/Livewire/FulfillmentModal.php
+++ b/src/Livewire/FulfillmentModal.php
@@ -96,10 +96,12 @@ final class FulfillmentModal extends Component
         $this->orderTime = $this->location->orderDateTime()->format('H:i');
         $this->hideDeliveryAddress = !$this->location->orderTypeIsDelivery();
 
-        if (!$this->location->hasLaterSchedule()) {
-            $this->isAsap = true;
-        } elseif (!$this->location->hasAsapSchedule()) {
-            $this->isAsap = false;
+        if ($this->location->current()) {
+            if (!$this->location->hasLaterSchedule()) {
+                $this->isAsap = true;
+            } elseif (!$this->location->hasAsapSchedule()) {
+                $this->isAsap = false;
+            }
         }
 
         $this->updateCurrentOrderType();

--- a/src/Livewire/FulfillmentModal.php
+++ b/src/Livewire/FulfillmentModal.php
@@ -79,6 +79,8 @@ final class FulfillmentModal extends Component
     {
         return view('igniter-orange::livewire.fulfillment-modal', [
             'orderTypes' => $this->location->getActiveOrderTypes(),
+            'showAsapOption' => $this->location->hasAsapSchedule(),
+            'showLaterOption' => $this->location->hasLaterSchedule(),
         ]);
     }
 
@@ -93,6 +95,12 @@ final class FulfillmentModal extends Component
         $this->orderDate = $this->location->orderDateTime()->format('Y-m-d');
         $this->orderTime = $this->location->orderDateTime()->format('H:i');
         $this->hideDeliveryAddress = !$this->location->orderTypeIsDelivery();
+
+        if (!$this->location->hasLaterSchedule()) {
+            $this->isAsap = true;
+        } elseif (!$this->location->hasAsapSchedule()) {
+            $this->isAsap = false;
+        }
 
         $this->updateCurrentOrderType();
     }
@@ -215,7 +223,7 @@ final class FulfillmentModal extends Component
     protected function updateTimeslot(): void
     {
         $timeSlotDateTime = $this->isAsap ? now() : make_carbon($this->orderDate.' '.$this->orderTime);
-        throw_unless($this->location->checkOrderTime($timeSlotDateTime), ValidationException::withMessages([
+        throw_unless($this->location->checkOrderTime($timeSlotDateTime, null, $this->isAsap), ValidationException::withMessages([
             'isAsap' => sprintf(lang('igniter.local::default.alert_order_is_unavailable'), $this->location->getOrderType()->getLabel()),
         ]));
 

--- a/tests/Livewire/FulfillmentModalTest.php
+++ b/tests/Livewire/FulfillmentModalTest.php
@@ -106,6 +106,18 @@ it('confirms order fulfillment options', function(): void {
         ->assertRedirect();
 });
 
+it('hides the Later radio when the order type is ASAP only', function(): void {
+    $this->location->settings()->create([
+        'item' => LocationModel::DELIVERY,
+        'data' => ['is_enabled' => 1, 'order_time_restriction' => 1],
+    ]);
+
+    Livewire::test(FulfillmentModal::class)
+        ->assertViewHas('showLaterOption', false)
+        ->assertViewHas('showAsapOption', true)
+        ->assertSet('isAsap', true);
+});
+
 it('updates search query', function(): void {
     $area = LocationArea::factory()->create([
         'type' => 'polygon',

--- a/tests/Livewire/FulfillmentModalTest.php
+++ b/tests/Livewire/FulfillmentModalTest.php
@@ -118,6 +118,18 @@ it('hides the Later radio when the order type is ASAP only', function(): void {
         ->assertSet('isAsap', true);
 });
 
+it('hides the ASAP radio when the order type is Later only', function(): void {
+    $this->location->settings()->create([
+        'item' => LocationModel::DELIVERY,
+        'data' => ['is_enabled' => 1, 'order_time_restriction' => 2],
+    ]);
+
+    Livewire::test(FulfillmentModal::class)
+        ->assertViewHas('showAsapOption', false)
+        ->assertViewHas('showLaterOption', true)
+        ->assertSet('isAsap', false);
+});
+
 it('updates search query', function(): void {
     $area = LocationArea::factory()->create([
         'type' => 'polygon',


### PR DESCRIPTION
## Summary

The fulfillment modal previously rendered both **ASAP** and **Later** radios unconditionally and called `Location::checkOrderTime()` without communicating the customer's choice. As a result an `ASAP_ONLY` (or `LATER_ONLY`) location silently accepted bookings of the disallowed kind — both in the UI and on submit.

This PR makes the modal honour the order type's schedule restriction:

| Change | Effect |
|---|---|
| `render()` exposes `showAsapOption` / `showLaterOption` from existing `Location::hasAsapSchedule()` / `Location::hasLaterSchedule()` | Inapplicable radio is removed from the DOM. |
| `timeslot.blade.php` wraps each radio in the matching `@if` (with `?? true` fallback so the partial stays safe to include from other contexts) | Same. |
| `mount()` coerces `\$this->isAsap` to a coherent value when only one option is available | Reopening the modal does not show a stale "Later" state. |
| `updateTimeslot()` forwards `\$this->isAsap` as the new third argument of `Location::checkOrderTime()` | Backend gate can reject crafted Livewire payloads even when the UI is bypassed. |

## Dependency

The new `checkOrderTime(..., \$isAsap)` parameter lands in `tastyigniter/ti-ext-local#112`, which depends on `tastyigniter/ti-ext-cart#127`. The extra argument is silently ignored by older releases of ti-ext-local, so this PR is forward-compatible — it just doesn't fully enforce on the backend until those two ship.

## Test plan

- [x] `it hides the Later radio when the order type is ASAP only` — asserts `showLaterOption=false`, `showAsapOption=true`, and `isAsap=true` after mount when delivery is configured `order_time_restriction = ASAP_ONLY`.

A backend-rejection test was deliberately omitted from this PR because it depends on `ti-ext-local#112` shipping; the same scenario is covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)