### PR TITLE
Release v4.1.8

### DIFF
--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -209,7 +209,7 @@ final class Checkout extends Component
     #[Computed]
     public function paymentGateways()
     {
-        return $this->getOrder()->order_total > 0
+        return number_format($this->getOrder()->order_total, 2) > 0
             ? $this->orderManager->getPaymentGateways()
             : collect();
     }


### PR DESCRIPTION
This release includes a minor bug fix for order total comparison during checkout.

## Fixed

- Used `number_format` when comparing the order total against zero to ensure accurate numeric formatting and avoid false mismatches during checkout