### PR TITLE
Fix: hide menu items that belong only to disabled categories

### DIFF
--- a/src/Actions/ListMenuItems.php
+++ b/src/Actions/ListMenuItems.php
@@ -35,6 +35,10 @@ class ListMenuItems
             ->withCount([
                 'menu_options',
             ])
+            ->where(fn($q) => $q
+                ->whereHas('categories', fn($q) => $q->whereIsEnabled())
+                ->orWhereDoesntHave('categories')
+            )
             ->with($with)
             ->listFrontEnd(array_except($filters, ['pageLimit']));
 

--- a/tests/Actions/ListMenuItemsTest.php
+++ b/tests/Actions/ListMenuItemsTest.php
@@ -41,6 +41,27 @@ it('returns grouped items when isGrouped is true and no category specified', fun
         ->and($action->getCategoryList())->toHaveKey($category->getKey());
 });
 
+it('excludes menu item attached only to a disabled category', function(): void {
+    $disabledCategory = Category::factory()->create(['status' => 0]);
+    $menuItem = Menu::factory()->create();
+    $menuItem->categories()->attach($disabledCategory);
+
+    $result = (new ListMenuItems)->handle(['pageLimit' => 20])->getList();
+
+    expect($result->getCollection()->contains(fn(MenuItemData $d) => $d->id === $menuItem->getKey()))->toBeFalse();
+});
+
+it('includes menu item attached to both an enabled and a disabled category', function(): void {
+    $enabledCategory = Category::factory()->create(['status' => 1]);
+    $disabledCategory = Category::factory()->create(['status' => 0]);
+    $menuItem = Menu::factory()->create();
+    $menuItem->categories()->attach([$enabledCategory->getKey(), $disabledCategory->getKey()]);
+
+    $result = (new ListMenuItems)->handle(['pageLimit' => 20])->getList();
+
+    expect($result->getCollection()->contains(fn(MenuItemData $d) => $d->id === $menuItem->getKey()))->toBeTrue();
+});
+
 it('groups items without categories under key 0', function(): void {
     Menu::factory()->create();
 


### PR DESCRIPTION
## Summary

- Menu items whose only category has `status = 0` (disabled) were still appearing on the menu page after the category was disabled in admin.
- Root cause: `CategoryScope` (a global scope that applies `WHERE status = 1` to all Category queries) was emptying the eager-loaded `categories` collection for these items, making them indistinguishable from truly uncategorised items at the PHP level.
- Fix: moves the visibility check to the query level in `ListMenuItems::handle()` — only menu items that have at least one enabled category, **or** no category at all, are returned.

Fixes: https://github.com/tastyigniter/TastyIgniter/issues/1173

## Test plan

- [ ] Disable a category in admin → its items should no longer appear on the menu page
- [ ] Re-enable the category → its items should reappear
- [ ] Items belonging to both an enabled and a disabled category remain visible (grouped under the enabled category only)
- [ ] Items with no category assignment continue to appear in the uncategorised section

🤖 Generated with [Claude Code](https://claude.com/claude-code)