### PR TITLE
Fix TypeError when tip amount input is cleared

### DIFF
--- a/src/Livewire/CartBox.php
+++ b/src/Livewire/CartBox.php
@@ -85,10 +85,10 @@ final class CartBox extends Component
         $this->cartManager = resolve(CartManager::class);
     }
 
-    public function updated($property, int|string|float $value): void
+    public function updated($property, int|string|float|null $value): void
     {
         if ($property === 'tipAmount') {
-            $this->onApplyTip($value, true);
+            $this->onApplyTip((float) $value, true);
         }
     }
 


### PR DESCRIPTION
## Summary

- Clearing the custom tip input field sends `null` to the `updated()` lifecycle hook
- The `$value` parameter type was `int|string|float`, which rejected `null` with a `TypeError`
- Widened the type to `int|string|float|null` and cast to `(float)` before passing to `onApplyTip()`, so empty input coerces to `0.0`

Fixes: https://github.com/tastyigniter/TastyIgniter/issues/1174

## Test plan

- [ ] Enable tipping in Cart Settings
- [ ] Add a custom tip amount in the cart
- [ ] Clear the tip input field completely — should apply a `0` tip without throwing a `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)