### PR TITLE
feat: show/hide menu options conditionally based on sibling selection

### DIFF
--- a/resources/js/cart-item-options.js
+++ b/resources/js/cart-item-options.js
@@ -1,14 +1,23 @@
-window.OrangeCartItemOptions = (min, max) => {
+window.OrangeCartItemOptions = (min, max, linkedValueIds = []) => {
     return {
         minSelection: min,
         maxSelection: max,
+        linkedValueIds,
+        isVisible() {
+            if (!this.linkedValueIds.length) return true
+            const menuOptions = Object.values(this.$wire.menuOptions ?? {})
+            return menuOptions.some((opt) => {
+                const vals = [].concat(opt?.option_values ?? [])
+                return vals.some((v) => this.linkedValueIds.includes(+v))
+            })
+        },
         toggleSelection() {
             if (this.maxSelection <= 0)
-                return;
+                return
 
-            const selectedCount = this.$el.querySelectorAll('input[type="checkbox"][data-option-price]:checked:not([disabled])').length;
+            const selectedCount = this.$el.querySelectorAll('input[type="checkbox"][data-option-price]:checked:not([disabled])').length
 
-            [...this.$el.querySelectorAll('input[type="checkbox"][data-option-price]:not(:checked)')]
+            ;[...this.$el.querySelectorAll('input[type="checkbox"][data-option-price]:not(:checked)')]
                 .forEach(($el) => {
                     selectedCount === this.maxSelection ? $el.setAttribute('disabled', 'disabled') : $el.removeAttribute('disabled')
                 })
@@ -24,12 +33,12 @@ window.OrangeCartItemOptions = (min, max) => {
 
                 if ($el.data('toggle') == 'more-options') {
                     $el.fadeOut()
-                    $container.find('[data-toggle="less-options"]').fadeIn();
-                    $container.find('.hidden-item-options').fadeIn();
+                    $container.find('[data-toggle="less-options"]').fadeIn()
+                    $container.find('.hidden-item-options').fadeIn()
                 } else {
                     $el.fadeOut()
-                    $container.find('[data-toggle="more-options"]').fadeIn();
-                    $container.find('.hidden-item-options').fadeOut();
+                    $container.find('[data-toggle="more-options"]').fadeIn()
+                    $container.find('.hidden-item-options').fadeOut()
                 }
             })
         }

--- a/resources/js/cart-item-options.js
+++ b/resources/js/cart-item-options.js
@@ -1,8 +1,9 @@
-window.OrangeCartItemOptions = (min, max, linkedValueIds = []) => {
+window.OrangeCartItemOptions = (min, max, linkedValueIds = [], menuOptionId = null) => {
     return {
         minSelection: min,
         maxSelection: max,
         linkedValueIds,
+        menuOptionId,
         isVisible() {
             if (!this.linkedValueIds.length) return true
             const menuOptions = Object.values(this.$wire.menuOptions ?? {})
@@ -23,6 +24,14 @@ window.OrangeCartItemOptions = (min, max, linkedValueIds = []) => {
                 })
         },
         init() {
+            if (this.linkedValueIds.length && this.menuOptionId !== null) {
+                this.$watch(() => this.isVisible(), (visible) => {
+                    if (!visible) {
+                        this.$wire.set(`menuOptions.${this.menuOptionId}.option_values`, [], false)
+                    }
+                })
+            }
+
             Livewire.on('cartItemTotalCalculated', () => {
                 this.toggleSelection()
             })

--- a/resources/views/includes/cartbox/item-options.blade.php
+++ b/resources/views/includes/cartbox/item-options.blade.php
@@ -1,6 +1,7 @@
 @foreach ($menuItemData->getOptions() as $index => $menuOption)
     <div
-        x-data="OrangeCartItemOptions({{ $menuOption->min_selected }}, {{ $menuOption->max_selected }})"
+        x-data="OrangeCartItemOptions({{ $menuOption->min_selected }}, {{ $menuOption->max_selected }}, {{ json_encode($menuOption->linked_option_value_ids) }})"
+        x-show="isVisible()"
         class="menu-option mb-3"
         data-control="item-option"
         data-option-type="{{ $menuOption->display_type }}"

--- a/resources/views/includes/cartbox/item-options.blade.php
+++ b/resources/views/includes/cartbox/item-options.blade.php
@@ -1,6 +1,6 @@
 @foreach ($menuItemData->getOptions() as $index => $menuOption)
     <div
-        x-data="OrangeCartItemOptions({{ $menuOption->min_selected }}, {{ $menuOption->max_selected }}, {{ json_encode($menuOption->linked_option_value_ids) }})"
+        x-data="OrangeCartItemOptions({{ $menuOption->min_selected }}, {{ $menuOption->max_selected }}, {{ json_encode($menuOption->linked_option_value_ids) }}, {{ $menuOption->menu_option_id }})"
         x-show="isVisible()"
         class="menu-option mb-3"
         data-control="item-option"


### PR DESCRIPTION
## Summary
- Adds `isVisible()` logic to `OrangeCartItemOptions` that reads `$wire.menuOptions` reactively to show/hide a menu option based on whether any of its linked parent values are currently selected
- Updates `item-options.blade.php` to pass `linked_option_value_ids` to each option component and apply `x-show="isVisible()"`

## Test plan
- Add a menu item with two options (e.g. Size and Toppings)
- In admin, configure Toppings to be conditional on Size: Large
- On the frontend, open the menu item modal — Toppings should be hidden initially
- Select Size: Large — Toppings should appear
- Select a different Size — Toppings should hide again

🤖 Generated with [Claude Code](https://claude.com/claude-code)