### PR TITLE
Release v4.1.10

### DIFF
--- a/src/Livewire/FulfillmentModal.php
+++ b/src/Livewire/FulfillmentModal.php
@@ -183,16 +183,12 @@ final class FulfillmentModal extends Component
 
     protected function updateCurrentOrderType(): void
     {
-        if (!$this->location->current()) {
+        if (!$this->location->current() || $this->location->getActiveOrderTypes()->isEmpty()) {
             return;
         }
 
         $sessionOrderType = $this->location->getSession('orderType');
         if ($sessionOrderType && $this->location->hasOrderType($sessionOrderType)) {
-            return;
-        }
-
-        if ($this->location->getActiveOrderTypes()->isEmpty()) {
             return;
         }
 

--- a/src/Livewire/FulfillmentModal.php
+++ b/src/Livewire/FulfillmentModal.php
@@ -192,9 +192,13 @@ final class FulfillmentModal extends Component
             return;
         }
 
+        if ($this->location->getActiveOrderTypes()->isEmpty()) {
+            return;
+        }
+
         $orderType = $this->defaultOrderType;
         if (!$this->location->hasOrderType($orderType)) {
-            $orderType = optional($this->location->getOrderTypes()->first(fn(AbstractOrderType $orderType): bool => !$orderType->isDisabled()))->getCode();
+            $orderType = optional($this->location->getActiveOrderTypes()->first())->getCode();
         }
 
         if ($orderType !== $this->orderType) {


### PR DESCRIPTION
This release includes bug fixes for the FulfillmentModal to handle edge cases around missing or empty order types.

## Fixed

- Added a guard to prevent errors when order types are empty before performing a session check
- Order type initialization is now skipped when no active order types exist, avoiding unnecessary or erroneous setup