### PR TITLE
feat(checkout): support partial-type checkout fields

### DIFF
--- a/resources/views/includes/checkout/field-partial.blade.php
+++ b/resources/views/includes/checkout/field-partial.blade.php
@@ -1,0 +1,4 @@
+@include($field->path, [
+    'field' => $field,
+    'orderModel' => $orderModel,
+])


### PR DESCRIPTION
## Summary
- Adds `includes/checkout/field-partial.blade.php` so extensions can point a checkout field at an arbitrary blade view via `'type' => 'partial', 'path' => '...'`, matching the existing `FormField` `$path` + `'partial'` convention already used elsewhere in admin forms.
- Needed by `igniterlabs/ti-ext-stripeterminal`'s new kiosk mode, which renders custom checkout fields (customer picker, mode toggle) this way.

## Test plan
- [ ] Confirm existing checkout field types (text, email, checkbox, telephone, textarea, payments) still render unaffected.
- [ ] Confirm a field with `'type' => 'partial', 'path' => 'some.view'` renders that view with `$field` and `$orderModel` available.