### PR TITLE
fix(checkout): still require a delivery address when the area restriction is disabled

### DIFF
--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -376,14 +376,21 @@ final class Checkout extends Component
 
         $this->withValidator(function($validator) use ($order): void {
             $validator->after(function($validator) use ($order): void {
-                if ($order->isDeliveryType() && Location::requiresUserPosition()) {
-                    rescue(function(): void {
-                        $this->orderManager->validateDeliveryAddress(array_only($this->fields, [
-                            'address_1', 'city', 'state', 'postcode', 'country',
-                        ]));
-                    }, function(Throwable $ex) use ($validator): void {
-                        $validator->errors()->add('delivery_address', $ex->getMessage());
-                    });
+                if ($order->isDeliveryType()) {
+                    if (Location::requiresUserPosition()) {
+                        rescue(function(): void {
+                            $this->orderManager->validateDeliveryAddress(array_only($this->fields, [
+                                'address_1', 'city', 'state', 'postcode', 'country',
+                            ]));
+                        }, function(Throwable $ex) use ($validator): void {
+                            $validator->errors()->add('delivery_address', $ex->getMessage());
+                        });
+                    } elseif (blank(array_get($this->fields, 'address_1'))) {
+                        // The delivery area restriction is disabled, so the address is
+                        // deliberately not geocoded or area-checked. It must still exist:
+                        // a delivery order without a street address cannot be delivered.
+                        $validator->errors()->add('delivery_address', lang('igniter.local::default.alert_missing_street_address'));
+                    }
                 }
 
                 if ($this->fields['payment'] && !$this->orderManager->getPayment($this->fields['payment'])) {

--- a/tests/Livewire/CheckoutTest.php
+++ b/tests/Livewire/CheckoutTest.php
@@ -277,6 +277,39 @@ it('onValidate adds a delivery address error when delivery address validation fa
         ->assertHasErrors(['delivery_address' => [lang('igniter.local::default.alert_missing_street_address')]]);
 });
 
+it('onValidate requires a delivery address when the delivery area restriction is disabled', function(): void {
+    setting()->set(['location_order' => '0']);
+    setupCheckout();
+
+    // No usable position, so no address is prepared onto the order
+    LocationFacade::updateUserPosition(new GeoliteLocation('test'));
+
+    $order = resolve(OrderManager::class)->getOrder();
+    $order->order_type = Location::DELIVERY;
+    $order->save();
+    LocationFacade::updateOrderType(Location::DELIVERY);
+
+    Livewire::test(Checkout::class)
+        ->dispatch('checkout::validate')
+        ->assertHasErrors(['delivery_address' => [lang('igniter.local::default.alert_missing_street_address')]]);
+});
+
+it('onValidate does not geocode the delivery address when the delivery area restriction is disabled', function(): void {
+    setting()->set(['location_order' => '0']);
+    setupCheckout();
+
+    $order = resolve(OrderManager::class)->getOrder();
+    $order->order_type = Location::DELIVERY;
+    $order->save();
+    LocationFacade::updateOrderType(Location::DELIVERY);
+
+    Geocoder::shouldReceive('geocode')->never();
+
+    Livewire::test(Checkout::class)
+        ->dispatch('checkout::validate')
+        ->assertHasNoErrors('delivery_address');
+});
+
 it('onValidate dispatches an event on success', function(): void {
     Event::fake(['igniter.orange.validateCheckout']);
     setupCheckout();


### PR DESCRIPTION
### The problem

Since a252f72d (`v4.2.0`), the delivery address check in `Checkout::validateCheckout()` is gated on `Location::requiresUserPosition()`:

```php
if ($order->isDeliveryType() && Location::requiresUserPosition()) {
```

`requiresUserPosition()` is `setting('location_order') == 1` — the **"Reject Orders Outside Delivery Area"** setting, which **ships disabled by default** (`core/database/records/settings.json`).

So on a default install, a **delivery** order can be placed with **no address at all**. The order is accepted with `address_id = NULL`, and the restaurant is left with an order it cannot deliver.

There is no second line of defence: the address fields are not part of `resources/models/checkoutfields.php`, so no validation rule covers them. They are populated solely by `prepareDeliveryAddress()` from the user position. When no position is set, `$this->fields` simply has no address keys — and that skipped `after()` callback was the only thing checking.

### How to reproduce

1. Leave "Reject Orders Outside Delivery Area" disabled (the default).
2. Reach checkout in delivery mode without setting an address via the fulfilment modal.
3. Place the order → it is accepted, `orders.address_id` is `NULL`.

Observed on three production installs after upgrading to `v4.2.0`; an install still on `v4.1.6` correctly blocks the same attempt with the same setting disabled.

### The fix

This keeps the intent of a252f72d fully intact — when the restriction is off, the address is still **not** geocoded and **not** area-checked, so customers are not blocked by geocoder failures, which is what that commit set out to fix.

It only adds back the weaker invariant: the address must **exist**. A delivery order without a street address is undeliverable regardless of whether the delivery area is enforced.

```php
if ($order->isDeliveryType()) {
    if (Location::requiresUserPosition()) {
        // unchanged: geocode + delivery-area validation
    } elseif (blank(array_get($this->fields, 'address_1'))) {
        $validator->errors()->add('delivery_address', lang('igniter.local::default.alert_missing_street_address'));
    }
}
```

Reuses the existing `igniter.local::default.alert_missing_street_address` string, so no new translations are needed.

### Tests

Two tests added:

- `onValidate requires a delivery address when the delivery area restriction is disabled` — asserts the error is raised.
- `onValidate does not geocode the delivery address when the delivery area restriction is disabled` — asserts `Geocoder::geocode()` is **never** called when an address is present, pinning the behaviour a252f72d introduced so it cannot regress.

`tests/Livewire/CheckoutTest.php` results (PHP 8.3, MariaDB 11):

| | result |
|---|---|
| baseline (this branch's base) | 1 failed, 20 passed |
| with this change | 1 failed, 22 passed |

The single failure is **pre-existing and identical on the unmodified base** (`onValidate adds a delivery address error when delivery address validation fails`, a `ViewException` in my environment) — it is not affected by this change. `vendor/bin/pint` passes on both changed files.
