### PR TITLE
fix(checkout): persist recomputed order total when payment method changes

### DIFF
--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -299,10 +299,12 @@ final class Checkout extends Component
         $this->checkoutForm->getField('payment')->value = $code;
         $this->orderManager->applyCurrentPaymentFee($payment->code);
 
-        if ($this->order->payment !== $code || $this->order->order_total !== $this->cartManager->getCart()->total()) {
+        $cartTotal = $this->cartManager->getCart()->total();
+
+        if ($this->order->payment !== $code || $this->order->order_total !== $cartTotal) {
             $this->order->updateQuietly([
                 'payment' => $code,
-                'order_total' => $this->cartManager->getCart()->total(),
+                'order_total' => $cartTotal,
             ]);
         }
 

--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -299,8 +299,11 @@ final class Checkout extends Component
         $this->checkoutForm->getField('payment')->value = $code;
         $this->orderManager->applyCurrentPaymentFee($payment->code);
 
-        if ($this->order->payment !== $code) {
-            $this->order->updateQuietly(['payment' => $code]);
+        if ($this->order->payment !== $code || $this->order->order_total !== $this->cartManager->getCart()->total()) {
+            $this->order->updateQuietly([
+                'payment' => $code,
+                'order_total' => $this->cartManager->getCart()->total(),
+            ]);
         }
 
         $this->order = null;


### PR DESCRIPTION
## Problem

When switching payment methods during checkout, only the payment code was saved to the order. The `order_total` attribute in memory had already been computed before the fee was applied for the request, so `updateQuietly()` could persist a stale, pre-fee total alongside the new payment code.

Companion fix to [tastyigniter/ti-ext-cart#138](https://github.com/tastyigniter/ti-ext-cart/pull/138), which addresses why the fee wasn't applying in the first place.

## Fix

`Checkout::onChoosePayment()` now recomputes and saves `order_total` from the cart alongside `payment` whenever either has changed, so the persisted order always matches the currently selected payment method.