### PR TITLE
Release v4.2.1

### DIFF
--- a/resources/views/includes/checkout/field-partial.blade.php
+++ b/resources/views/includes/checkout/field-partial.blade.php
@@ -1,0 +1,4 @@
+@include($field->path, [
+    'field' => $field,
+    'orderModel' => $orderModel,
+])

--- a/resources/views/includes/checkout/field-select.blade.php
+++ b/resources/views/includes/checkout/field-select.blade.php
@@ -1,0 +1,21 @@
+<div @class(['form-floating', 'is-invalid' => has_form_error($field->getName())])>
+    <select
+        wire:model="{{ $field->getName() }}"
+        data-checkout-control="{{ $field->fieldName }}"
+        id="{{ $field->getId() }}"
+        @class(['form-select', 'is-invalid' => has_form_error($field->getName())])
+        aria-describedby="{{ $field->getId() }}-feedback"
+        {!! $field->getAttributes() !!}
+    >
+        <option value="">@lang('igniter::admin.text_please_select')</option>
+        @foreach ($field->options() as $value => $label)
+            <option value="{{ $value }}">{{ $label }}</option>
+        @endforeach
+    </select>
+    <label for="{{ $field->getId() }}">@lang($field->label)</label>
+</div>
+<x-igniter-orange::forms.error
+    field="{{ $field->getName() }}"
+    id="{{ $field->getId() }}-feedback"
+    class="text-danger"
+/>

--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -299,8 +299,13 @@ final class Checkout extends Component
         $this->checkoutForm->getField('payment')->value = $code;
         $this->orderManager->applyCurrentPaymentFee($payment->code);
 
-        if ($this->order->payment !== $code) {
-            $this->order->updateQuietly(['payment' => $code]);
+        $cartTotal = $this->cartManager->getCart()->total();
+
+        if ($this->order->payment !== $code || $this->order->order_total !== $cartTotal) {
+            $this->order->updateQuietly([
+                'payment' => $code,
+                'order_total' => $cartTotal,
+            ]);
         }
 
         $this->order = null;

--- a/src/Livewire/Checkout.php
+++ b/src/Livewire/Checkout.php
@@ -381,14 +381,21 @@ final class Checkout extends Component
 
         $this->withValidator(function($validator) use ($order): void {
             $validator->after(function($validator) use ($order): void {
-                if ($order->isDeliveryType() && Location::requiresUserPosition()) {
-                    rescue(function(): void {
-                        $this->orderManager->validateDeliveryAddress(array_only($this->fields, [
-                            'address_1', 'city', 'state', 'postcode', 'country',
-                        ]));
-                    }, function(Throwable $ex) use ($validator): void {
-                        $validator->errors()->add('delivery_address', $ex->getMessage());
-                    });
+                if ($order->isDeliveryType()) {
+                    if (Location::requiresUserPosition()) {
+                        rescue(function(): void {
+                            $this->orderManager->validateDeliveryAddress(array_only($this->fields, [
+                                'address_1', 'city', 'state', 'postcode', 'country',
+                            ]));
+                        }, function(Throwable $ex) use ($validator): void {
+                            $validator->errors()->add('delivery_address', $ex->getMessage());
+                        });
+                    } elseif (blank(array_get($this->fields, 'address_1'))) {
+                        // The delivery area restriction is disabled, so the address is
+                        // deliberately not geocoded or area-checked. It must still exist:
+                        // a delivery order without a street address cannot be delivered.
+                        $validator->errors()->add('delivery_address', lang('igniter.local::default.alert_missing_street_address'));
+                    }
                 }
 
                 if ($this->fields['payment'] && !$this->orderManager->getPayment($this->fields['payment'])) {

--- a/src/Livewire/Concerns/SearchesNearby.php
+++ b/src/Livewire/Concerns/SearchesNearby.php
@@ -285,7 +285,7 @@ trait SearchesNearby
 
         $userLocation = $this->handleGeocodeResponse($collection);
 
-        $this->searchQuery = $userLocation->format();
+        $this->searchQuery = $userLocation->getFormattedAddress();
 
         return $userLocation;
     }

--- a/src/View/Components/AccountDashboard.php
+++ b/src/View/Components/AccountDashboard.php
@@ -19,9 +19,9 @@ final class AccountDashboard extends Component
 
     public ?int $defaultAddressId;
 
-    public string $formattedAddress = '';
+    public string $formattedAddress;
 
-    public string $customerName = '';
+    public string $customerName;
 
     public function __construct()
     {

--- a/tests/Livewire/CheckoutTest.php
+++ b/tests/Livewire/CheckoutTest.php
@@ -277,6 +277,39 @@ it('onValidate adds a delivery address error when delivery address validation fa
         ->assertHasErrors(['delivery_address' => [lang('igniter.local::default.alert_missing_street_address')]]);
 });
 
+it('onValidate requires a delivery address when the delivery area restriction is disabled', function(): void {
+    setting()->set(['location_order' => '0']);
+    setupCheckout();
+
+    // No usable position, so no address is prepared onto the order
+    LocationFacade::updateUserPosition(new GeoliteLocation('test'));
+
+    $order = resolve(OrderManager::class)->getOrder();
+    $order->order_type = Location::DELIVERY;
+    $order->save();
+    LocationFacade::updateOrderType(Location::DELIVERY);
+
+    Livewire::test(Checkout::class)
+        ->dispatch('checkout::validate')
+        ->assertHasErrors(['delivery_address' => [lang('igniter.local::default.alert_missing_street_address')]]);
+});
+
+it('onValidate does not geocode the delivery address when the delivery area restriction is disabled', function(): void {
+    setting()->set(['location_order' => '0']);
+    setupCheckout();
+
+    $order = resolve(OrderManager::class)->getOrder();
+    $order->order_type = Location::DELIVERY;
+    $order->save();
+    LocationFacade::updateOrderType(Location::DELIVERY);
+
+    Geocoder::shouldReceive('geocode')->never();
+
+    Livewire::test(Checkout::class)
+        ->dispatch('checkout::validate')
+        ->assertHasNoErrors('delivery_address');
+});
+
 it('onValidate dispatches an event on success', function(): void {
     Event::fake(['igniter.orange.validateCheckout']);
     setupCheckout();

--- a/tests/Livewire/LocalSearchTest.php
+++ b/tests/Livewire/LocalSearchTest.php
@@ -192,12 +192,13 @@ it('onUserPositionUpdated updates user position in session correctly', function(
             'streetName' => 'Main St',
             'latitude' => 51.50987615,
             'longitude' => -0.1446716,
+            'formattedAddress' => '123 Main St',
         ]),
     ]));
 
     Livewire::test(LocalSearch::class)
         ->call('onUserPositionUpdated', [51.50987615, -0.1446716])
-        ->assertSet('searchQuery', '123 Main St  ');
+        ->assertSet('searchQuery', '123 Main St');
 });
 
 it('onUpdateSearchQuery errors when no search query or point', function(): void {


### PR DESCRIPTION
This release improves checkout form flexibility with new field type support and fixes several bugs related to address handling, order totals, and delivery validation.

## Added

- Introduced a select field template for use in checkout forms
- Support for partial-type checkout fields in checkout forms

## Fixed

- Delivery address is now correctly required even when area restriction is disabled
- Order total is properly persisted when the payment method changes
- Fixed an issue where the local search autocomplete would display an incorrect address after a user selects one