### PR TITLE
Fix/menu option validation errors

### DIFF
--- a/resources/views/includes/cartbox/item-options.blade.php
+++ b/resources/views/includes/cartbox/item-options.blade.php
@@ -61,6 +61,11 @@
                         @include('igniter-orange::includes.cartbox.item-options-'.$menuOption->display_type)
                     @endif
                 </div>
+
+                <x-igniter-orange::forms.error
+                    field="menuOptions.{{ $menuOption->menu_option_id }}"
+                    class="text-danger mt-2"
+                />
             @endif
         </div>
     </div>

--- a/src/Livewire/CartItemModal.php
+++ b/src/Livewire/CartItemModal.php
@@ -127,6 +127,8 @@ final class CartItemModal extends ModalComponent
 
     public function onSave(): void
     {
+        $this->validateMenuOptions();
+
         try {
             $cartItem = $this->cartManager->addOrUpdateCartItem([
                 'menuId' => $this->menuId,
@@ -140,7 +142,7 @@ final class CartItemModal extends ModalComponent
 
             $this->dispatch('hideModal');
         } catch (Exception $exception) {
-            throw ValidationException::withMessages(['menuOptions' => $exception->getMessage()]);
+            throw ValidationException::withMessages(['menuOptions' => strip_tags($exception->getMessage())]);
         }
     }
 
@@ -163,6 +165,31 @@ final class CartItemModal extends ModalComponent
         }
 
         return $value;
+    }
+
+    protected function validateMenuOptions(): void
+    {
+        $errors = [];
+        $selectedOptions = collect($this->menuOptions);
+
+        foreach ($this->getMenuItemData()->getOptions() as $menuOption) {
+            $selectedOption = $selectedOptions->get($menuOption->getKey());
+            $selectedValues = array_filter((array)array_get($selectedOption, 'option_values', []));
+
+            if (!in_array($menuOption->option->display_type, ['quantity', 'checkbox'])) {
+                $selectedValues = array_filter($selectedValues, is_numeric(...));
+            }
+
+            try {
+                $this->cartManager->validateMenuItemOption($menuOption, $selectedValues);
+            } catch (Exception $exception) {
+                $errors['menuOptions.'.$menuOption->getKey()] = strip_tags($exception->getMessage());
+            }
+        }
+
+        if ($errors !== []) {
+            throw ValidationException::withMessages($errors);
+        }
     }
 
     protected function getCartItem(): ?CartItem


### PR DESCRIPTION
## Summary

This PR improves validation feedback for menu item options in the Orange cart item modal.

Currently, when multiple menu options are invalid or required but not selected, only the first validation error is shown. The customer then has to fix that option and submit again before the next validation error becomes visible.

This PR validates all menu options first and shows all validation errors at once, directly below the relevant menu option.

## Current behaviour

Given a menu item with multiple required options, for example:

- Basis
- Sauce
- Cutlery

If none of them are selected, only the first validation error is displayed.

After selecting that option and submitting again, the next validation error is shown.

This results in multiple submit attempts for menu items with several required or otherwise invalid options.

In addition, validation messages containing HTML formatting such as `<b>` or `<strong>` can be displayed literally because the Livewire error component escapes the validation message.

## New behaviour

All menu options are validated before the cart item is saved.

Validation errors are collected per menu option and added to Livewire using keys in the following format:

```php
menuOptions.{menu_option_id}